### PR TITLE
Add node selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Make sure to set the envorinment variables :
 
 - `process.env.REACT_APP_ASSET_ISSUER_SECRET` for the USDC and EUR issuer secret
 
-- `process.env.REACT_APP_AMM_ADDRESS` for the USDC and EUR issuer secret
+You can optionally provide these environment variables to change the connection parameters of the known nodes:
+
+- `process.env.REACT_APP_ROCOCO_WSS_ENDPOINT` used as the endpoint for the 'Rococo Testnet' node
+
+- `process.env.REACT_APP_ROCOCO_AMM_ADDRESS` for specifying the deployed AMM of the 'Rococo Testnet' node
 
 ## Run
 

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Pendulum Playground</title>
+    <title>Pendulum</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,18 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import './App.css';
 import Footer from './components/Footer';
 import { GlobalStateProvider } from './GlobalStateProvider';
+import PendulumApi from './lib/api';
 import MainContent from './Main';
 import theme from './theme';
 
 function App() {
   const saved = localStorage.getItem('state');
   const initialValue = JSON.parse(saved || '{}');
+
+  const api = PendulumApi.get();
+  if (initialValue.currentNode) {
+    api.init(initialValue.url);
+  }
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,14 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import './App.css';
 import Footer from './components/Footer';
 import { GlobalStateProvider } from './GlobalStateProvider';
-import PendulumApi from './lib/api';
 import MainContent from './Main';
 import theme from './theme';
 
-function App() {
-  const saved = localStorage.getItem('state');
-  const initialValue = JSON.parse(saved || '{}');
-
-  const api = PendulumApi.get();
-  if (initialValue.currentNode) {
-    api.init(initialValue.url);
-  }
-
+function App(props: { initialState: any }) {
   return (
     <ThemeProvider theme={theme}>
       <Router>
-        <GlobalStateProvider value={initialValue}>
+        <GlobalStateProvider value={props.initialState}>
           <MainContent />
           <Footer />
         </GlobalStateProvider>

--- a/src/GlobalStateProvider.tsx
+++ b/src/GlobalStateProvider.tsx
@@ -2,6 +2,10 @@ import { createContext, Dispatch, SetStateAction, useContext, useState } from 'r
 import { AccountKeyPairs } from './interfaces';
 import { Node } from './lib/nodes';
 
+export interface Toast {
+  message: string;
+  type: 'success' | 'error';
+}
 export interface GlobalStateInterface {
   accountSecret: string;
   accountName: string;
@@ -9,6 +13,7 @@ export interface GlobalStateInterface {
   ammAddress: string;
   currentNode: Node;
   infoMessage?: string;
+  toast?: Toast;
 }
 
 const GlobalStateContext = createContext({

--- a/src/GlobalStateProvider.tsx
+++ b/src/GlobalStateProvider.tsx
@@ -1,10 +1,13 @@
 import { createContext, Dispatch, SetStateAction, useContext, useState } from 'react';
 import { AccountKeyPairs } from './interfaces';
+import { Node } from './lib/nodes';
 
 export interface GlobalStateInterface {
   accountSecret: string;
   accountName: string;
   accountExtraData?: AccountKeyPairs;
+  ammAddress: string;
+  currentNode: Node;
   infoMessage?: string;
 }
 

--- a/src/GlobalStateProvider.tsx
+++ b/src/GlobalStateProvider.tsx
@@ -10,7 +10,6 @@ export interface GlobalStateInterface {
   accountSecret: string;
   accountName: string;
   accountExtraData?: AccountKeyPairs;
-  ammAddress: string;
   currentNode: Node;
   infoMessage?: string;
   toast?: Toast;

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,10 +1,12 @@
-import { Switch, Route, Redirect } from 'react-router-dom';
-import Balances from './components/Balances';
-import AMM from './components/AMM';
-import Topbar from './components/Topbar';
-import { createStyles, makeStyles } from '@mui/styles';
+import Snackbar from '@mui/material/Snackbar';
 import { Theme } from '@mui/material/styles';
+import { createStyles, makeStyles } from '@mui/styles';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import Alert from './components/Alert';
+import AMM from './components/AMM';
+import Balances from './components/Balances';
 import Bridge from './components/Bridge';
+import Topbar from './components/Topbar';
 import { useGlobalState } from './GlobalStateProvider';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -17,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function MainContent() {
   const classes = useStyles();
-  const { state } = useGlobalState();
+  const { state, setState } = useGlobalState();
 
   return (
     <div className={'App' + (state.accountSecret ? '' : ' disconnected')}>
@@ -34,6 +36,14 @@ export default function MainContent() {
           <Route exact path='/amm' component={AMM} />
         </Switch>
       </main>
+      <Snackbar
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        autoHideDuration={6000}
+        open={Boolean(state.toast)}
+        onClose={() => setState({ ...state, toast: undefined })}
+      >
+        {state.toast && <Alert severity={state.toast.type}>{state.toast.message}</Alert>}
+      </Snackbar>
     </div>
   );
 }

--- a/src/components/AMM/index.tsx
+++ b/src/components/AMM/index.tsx
@@ -64,7 +64,7 @@ function AmmView() {
     return (
       <>
         <Container maxWidth='sm' component='main'>
-          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
+          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.2em 0'>
             Connect your account
           </Typography>
         </Container>
@@ -74,12 +74,12 @@ function AmmView() {
   }
 
   return (
-    <Box sx={{ width: '100%', paddingBottom: 2, margin: '1.5em 0' }}>
+    <Box sx={{ width: '100%', paddingBottom: 2, margin: '1.2em 0' }}>
       {contract ? (
         <AmmTabs reserves={reserves} totalSupply={totalSupply} contract={contract} lpBalance={lpBalance} />
       ) : (
         <Container maxWidth='sm' component='main'>
-          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
+          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.2em 0'>
             Could not instantiate AMM contract
           </Typography>
         </Container>

--- a/src/components/AMM/index.tsx
+++ b/src/components/AMM/index.tsx
@@ -25,7 +25,7 @@ function AmmView() {
 
   const contract = React.useMemo(() => {
     try {
-      if (state.ammAddress && state.accountExtraData?.address) {
+      if (state.currentNode?.amm_address && state.accountExtraData?.address) {
         const api = PendulumApi.get();
         if (state.accountExtraData === undefined) return;
 
@@ -37,7 +37,7 @@ function AmmView() {
               userKeypair.unlock(undefined);
             } catch {}
           }
-          return PendulumApi.get().getAMMContract(userKeypair, state.ammAddress);
+          return PendulumApi.get().getAMMContract(userKeypair, state.currentNode?.amm_address);
         } else {
           return undefined;
         }
@@ -45,7 +45,7 @@ function AmmView() {
     } catch (error) {
       console.error(error);
     }
-  }, [state.accountExtraData]);
+  }, [state.accountExtraData, state.currentNode]);
 
   React.useEffect(() => {
     const fetchValues = () => {
@@ -78,7 +78,11 @@ function AmmView() {
       {contract ? (
         <AmmTabs reserves={reserves} totalSupply={totalSupply} contract={contract} lpBalance={lpBalance} />
       ) : (
-        <Typography variant='h6'>Could not instantiate AMM contract.</Typography>
+        <Container maxWidth='sm' component='main'>
+          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='01em 0'>
+            Could not instantiate AMM contract
+          </Typography>
+        </Container>
       )}
     </Box>
   );

--- a/src/components/AMM/index.tsx
+++ b/src/components/AMM/index.tsx
@@ -64,7 +64,7 @@ function AmmView() {
     return (
       <>
         <Container maxWidth='sm' component='main'>
-          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='01em 0'>
+          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
             Connect your account
           </Typography>
         </Container>
@@ -74,12 +74,12 @@ function AmmView() {
   }
 
   return (
-    <Box sx={{ width: '100%', paddingBottom: 2 }}>
+    <Box sx={{ width: '100%', paddingBottom: 2, margin: '1.5em 0' }}>
       {contract ? (
         <AmmTabs reserves={reserves} totalSupply={totalSupply} contract={contract} lpBalance={lpBalance} />
       ) : (
         <Container maxWidth='sm' component='main'>
-          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='01em 0'>
+          <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
             Could not instantiate AMM contract
           </Typography>
         </Container>

--- a/src/components/AMM/index.tsx
+++ b/src/components/AMM/index.tsx
@@ -25,7 +25,7 @@ function AmmView() {
 
   const contract = React.useMemo(() => {
     try {
-      if (state.accountExtraData?.address) {
+      if (state.ammAddress && state.accountExtraData?.address) {
         const api = PendulumApi.get();
         if (state.accountExtraData === undefined) return;
 
@@ -37,7 +37,7 @@ function AmmView() {
               userKeypair.unlock(undefined);
             } catch {}
           }
-          return PendulumApi.get().getAMMContract(userKeypair);
+          return PendulumApi.get().getAMMContract(userKeypair, state.ammAddress);
         } else {
           return undefined;
         }

--- a/src/components/AccountDialog.tsx
+++ b/src/components/AccountDialog.tsx
@@ -33,12 +33,12 @@ export default function AccountDialog(props: any) {
 
   const handleOneClickSetup = async () => {
     const setup = new OneClickSetup();
-    setup.setNotifyCallback((infoMessage: string) => setState({ infoMessage }));
+    setup.setNotifyCallback((infoMessage: string) => setState({ ...state, infoMessage }));
 
     setLoadingSetup(true);
     const res = await setup.createAccount();
     if (res) {
-      setState({ ...res, infoMessage: undefined });
+      setState({ ...res, ...state, infoMessage: undefined });
       setAccountName(res.accountName);
       setAccountSecret(res.accountSecret);
       setShowSecretKey(true);
@@ -47,14 +47,14 @@ export default function AccountDialog(props: any) {
   };
 
   const forgetAccount = () => {
-    setState({ accountName: '', accountSecret: '', accountExtraData: undefined });
+    setState({ ...state, accountName: '', accountSecret: '', accountExtraData: undefined });
     setAccountName('');
     setAccountSecret('');
   };
 
   const connectAccount = () => {
     const accountExtraData = api.addAccount(accountSecret, accountName);
-    setState({ accountName, accountSecret, accountExtraData });
+    setState({ ...state, accountName, accountSecret, accountExtraData });
     close();
   };
 

--- a/src/components/AccountDialog.tsx
+++ b/src/components/AccountDialog.tsx
@@ -38,7 +38,7 @@ export default function AccountDialog(props: any) {
     setLoadingSetup(true);
     const res = await setup.createAccount();
     if (res) {
-      setState({ ...res, ...state, infoMessage: undefined });
+      setState({ ...state, ...res, infoMessage: undefined });
       setAccountName(res.accountName);
       setAccountSecret(res.accountSecret);
       setShowSecretKey(true);

--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -14,7 +14,11 @@ import { Balance } from './Balances';
 
 const MIN_BALANCE = 100;
 
-export default function BalanceCard(props: any) {
+interface Props {
+  balance: Balance;
+}
+
+export default function BalanceCard(props: Props) {
   const { state } = useGlobalState();
   let { balance: prevBalance } = props;
   const [newBalance, setNewBalance] = useState<Balance>(prevBalance);
@@ -41,7 +45,7 @@ export default function BalanceCard(props: any) {
       }
     }
     bind();
-  }, [state, prevBalance, setNewBalance]);
+  }, [state.accountExtraData, prevBalance]);
 
   return (
     <Card

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -40,7 +40,7 @@ export default function Balances() {
   return (
     <React.Fragment>
       <Container maxWidth='sm' component='main'>
-        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
+        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.2em 0'>
           {state.accountSecret ? 'Balances overview' : 'Connect your account'}
         </Typography>
       </Container>

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -40,7 +40,7 @@ export default function Balances() {
   return (
     <React.Fragment>
       <Container maxWidth='sm' component='main'>
-        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='01em 0'>
+        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
           {state.accountSecret ? 'Balances overview' : 'Connect your account'}
         </Typography>
       </Container>

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -23,14 +23,19 @@ export default function Balances() {
       const api = PendulumApi.get();
       const address = state.accountExtraData?.address;
       if (address) {
-        let fetchedBalances = await api.getBalances(address);
-        setBalances(fetchedBalances);
+        try {
+          let fetchedBalances = await api.getBalances(address);
+          setBalances(fetchedBalances);
+        } catch (error) {
+          console.error('Could not fetch balances', error);
+          setBalances([]);
+        }
       } else {
         setBalances([]);
       }
     }
     fetch();
-  }, [state, setBalances]);
+  }, [state, state.currentNode]);
 
   return (
     <React.Fragment>

--- a/src/components/Bridge.tsx
+++ b/src/components/Bridge.tsx
@@ -94,7 +94,7 @@ export default function Bridge() {
   return (
     <React.Fragment>
       <Container maxWidth='sm' component='main'>
-        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='01em 0'>
+        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
           {state.accountSecret ? 'Account balances' : 'Connect your account'}
         </Typography>
       </Container>

--- a/src/components/Bridge.tsx
+++ b/src/components/Bridge.tsx
@@ -94,7 +94,7 @@ export default function Bridge() {
   return (
     <React.Fragment>
       <Container maxWidth='sm' component='main'>
-        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.5em 0'>
+        <Typography component='h1' variant='h4' align='center' color='text.primary' margin='1.2em 0'>
           {state.accountSecret ? 'Account balances' : 'Connect your account'}
         </Typography>
       </Container>

--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -1,0 +1,139 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import React from 'react';
+import { useGlobalState } from '../../GlobalStateProvider';
+import { getDefaultNode, knownNodes, Node, setDefaultNode } from '../../lib/nodes';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import PendulumApi from '../../lib/api';
+
+interface NodeSelectionProps {
+  onSave: () => void;
+}
+
+function NodeSelection(props: NodeSelectionProps) {
+  const { state, setState } = useGlobalState();
+  const [selectedNode, setSelectedNode] = React.useState<Node>(state.currentNode || getDefaultNode());
+
+  const [customNodeURL, setCustomNodeURL] = React.useState<string>(selectedNode.url);
+  const [customAMMAddress, setCustomAMMAddress] = React.useState<string>(selectedNode.amm_address);
+  const [showCustomNodeField, setShowCustomNodeField] = React.useState(selectedNode?.display_name === 'Custom');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    const newNodeDisplayName = event.target.value;
+    const existingNode = knownNodes.find((n) => n.display_name === newNodeDisplayName);
+    if (existingNode) {
+      setShowCustomNodeField(false);
+      setSelectedNode(existingNode);
+    } else {
+      setShowCustomNodeField(true);
+      setSelectedNode({ display_name: 'Custom', url: customNodeURL, amm_address: customAMMAddress });
+    }
+  };
+
+  const onSave = () => {
+    if (selectedNode?.display_name === 'Custom') {
+      const customNode = { ...selectedNode, url: customNodeURL, amm_address: customAMMAddress };
+      PendulumApi.get().init(customNode.url);
+      setState({ ...state, currentNode: customNode });
+      setDefaultNode(customNode);
+    } else if (selectedNode) {
+      PendulumApi.get().init(selectedNode.url);
+      setDefaultNode(selectedNode);
+      setState({ ...state, currentNode: selectedNode });
+    }
+
+    props.onSave();
+  };
+
+  return (
+    <Box sx={{ minWidth: 120, margin: 1 }}>
+      <Typography variant='h5' sx={{ marginBottom: 2 }}>
+        Node selection
+      </Typography>
+      <FormControl fullWidth>
+        <InputLabel id='node-select-label'>Node</InputLabel>
+        <Select
+          labelId='node-select-label'
+          id='node-select'
+          value={selectedNode?.display_name}
+          label='Node'
+          onChange={handleChange}
+        >
+          {knownNodes.map((node, index) => (
+            <MenuItem key={index} value={node.display_name}>
+              {node.display_name}
+            </MenuItem>
+          ))}
+          <MenuItem key='custom' value='Custom'>
+            Custom node
+          </MenuItem>
+        </Select>
+        {showCustomNodeField && (
+          <>
+            <TextField
+              label='Custom Node URL'
+              onChange={(e) => setCustomNodeURL(e.target.value)}
+              value={customNodeURL}
+              sx={{ marginTop: 2 }}
+              placeholder='ws://...'
+            />
+            <TextField
+              label='AMM Address (optional)'
+              onChange={(e) => setCustomAMMAddress(e.target.value)}
+              value={customAMMAddress}
+              sx={{ marginTop: 2 }}
+              placeholder='5CcuLN...'
+            />
+          </>
+        )}
+        <Button onClick={onSave} sx={{ marginTop: 1 }}>
+          Save
+        </Button>
+      </FormControl>
+    </Box>
+  );
+}
+
+function NodeSelectionDrawer() {
+  const { state } = useGlobalState();
+
+  console.log('state', state);
+
+  const [open, setOpen] = React.useState(false);
+
+  const toggleDrawer = (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
+    if (
+      event.type === 'keydown' &&
+      ((event as React.KeyboardEvent).key === 'Tab' || (event as React.KeyboardEvent).key === 'Shift')
+    ) {
+      return;
+    }
+
+    setOpen(open);
+  };
+
+  const closeDrawer = () => setOpen(false);
+
+  return (
+    <div>
+      <Button onClick={toggleDrawer(true)} endIcon={<KeyboardArrowDownIcon />} color='primary'>
+        {state.currentNode ? state.currentNode.display_name : 'Not connected'}
+      </Button>
+      <Drawer anchor='left' open={open} onClose={toggleDrawer(false)}>
+        <Box sx={{ width: 300, padding: 2 }} role='presentation'>
+          <NodeSelection onSave={closeDrawer} />
+        </Box>
+      </Drawer>
+    </div>
+  );
+}
+
+export default NodeSelectionDrawer;

--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -1,3 +1,5 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { LoadingButton } from '@mui/lab';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';
@@ -5,13 +7,12 @@ import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useGlobalState } from '../../GlobalStateProvider';
-import { getDefaultNode, knownNodes, Node, setDefaultNode } from '../../lib/nodes';
-import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 import PendulumApi from '../../lib/api';
+import { getDefaultNode, knownNodes, Node, setDefaultNode } from '../../lib/nodes';
 
 interface NodeSelectionProps {
   onSave: () => void;
@@ -21,9 +22,12 @@ function NodeSelection(props: NodeSelectionProps) {
   const { state, setState } = useGlobalState();
   const [selectedNode, setSelectedNode] = React.useState<Node>(state.currentNode || getDefaultNode());
 
-  const [customNodeURL, setCustomNodeURL] = React.useState<string>('ws://localhost:8844');
+  const [customNodeInputError, setCustomNodeInputError] = React.useState<string | null>(null);
+  const [customNodeEndpoint, setCustomNodeEndpoint] = React.useState<string>('ws://localhost:8844');
   const [customAMMAddress, setCustomAMMAddress] = React.useState<string>(selectedNode.amm_address);
   const [showCustomNodeField, setShowCustomNodeField] = React.useState(selectedNode?.display_name === 'Custom');
+
+  const [loading, setLoading] = React.useState(false);
 
   const handleChange = (event: SelectChangeEvent) => {
     const newNodeDisplayName = event.target.value;
@@ -33,25 +37,65 @@ function NodeSelection(props: NodeSelectionProps) {
       setSelectedNode(existingNode);
     } else {
       setShowCustomNodeField(true);
-      setSelectedNode({ display_name: 'Custom', url: customNodeURL, amm_address: customAMMAddress });
+      setSelectedNode({ display_name: 'Custom', wss_endpoint: customNodeEndpoint, amm_address: customAMMAddress });
     }
   };
 
-  const onSave = async () => {
-    if (selectedNode?.display_name === 'Custom') {
-      const customNode = { ...selectedNode, url: customNodeURL, amm_address: customAMMAddress };
-      // await initialization before changing global state because
-      // other components listen to state and would use potentially outdated api
-      await PendulumApi.get().init(customNode.url);
-      setState({ ...state, currentNode: customNode });
-      setDefaultNode(customNode);
-    } else if (selectedNode) {
-      await PendulumApi.get().init(selectedNode.url);
-      setDefaultNode(selectedNode);
-      setState({ ...state, currentNode: selectedNode });
+  const handleCustomNodeEndpointChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const url = event.target.value;
+    if (!url.startsWith('ws://') && !url.startsWith('wss://')) {
+      setCustomNodeInputError('Invalid WSS endpoint URL');
+    } else {
+      setCustomNodeInputError(null);
     }
 
-    props.onSave();
+    setCustomNodeEndpoint(url);
+  };
+
+  const onSave = async () => {
+    setLoading(true);
+    if (selectedNode?.display_name === 'Custom') {
+      const customNode = { ...selectedNode, url: customNodeEndpoint, amm_address: customAMMAddress };
+      // await initialization before changing global state because
+      // other components listen to state and would use potentially outdated api
+      try {
+        await PendulumApi.get().init(customNode.url);
+
+        setState({
+          ...state,
+          currentNode: customNode,
+          toast: { message: `Connected to ${customNode.url}`, type: 'success' }
+        });
+        setDefaultNode(customNode);
+        props.onSave();
+      } catch (error) {
+        // change currentNode even on error to prevent inconsistency
+        setState({
+          ...state,
+          currentNode: customNode,
+          toast: { message: `Failed to connect to ${customNode.url}`, type: 'error' }
+        });
+      }
+    } else if (selectedNode) {
+      try {
+        await PendulumApi.get().init(selectedNode.wss_endpoint);
+        setDefaultNode(selectedNode);
+        setState({
+          ...state,
+          currentNode: selectedNode,
+          toast: { message: `Connected to ${selectedNode.wss_endpoint}`, type: 'success' }
+        });
+        props.onSave();
+      } catch (error) {
+        // change currentNode even on error to prevent inconsistency
+        setState({
+          ...state,
+          currentNode: selectedNode,
+          toast: { message: `Failed to connect to ${selectedNode.wss_endpoint}`, type: 'error' }
+        });
+      }
+    }
+    setLoading(false);
   };
 
   return (
@@ -80,11 +124,13 @@ function NodeSelection(props: NodeSelectionProps) {
         {showCustomNodeField && (
           <>
             <TextField
-              label='Custom Node URL'
-              onChange={(e) => setCustomNodeURL(e.target.value)}
-              value={customNodeURL}
+              label='Custom Node Endpoint'
+              error={Boolean(customNodeInputError)}
+              helperText={customNodeInputError}
+              onChange={handleCustomNodeEndpointChange}
+              value={customNodeEndpoint}
               sx={{ marginTop: 2 }}
-              placeholder='ws://...'
+              placeholder='wss://...'
             />
             <TextField
               label='AMM Address (optional)'
@@ -95,9 +141,14 @@ function NodeSelection(props: NodeSelectionProps) {
             />
           </>
         )}
-        <Button onClick={onSave} sx={{ marginTop: 1 }}>
+        <LoadingButton
+          disabled={Boolean(customNodeInputError)}
+          loading={loading}
+          onClick={onSave}
+          sx={{ marginTop: 1 }}
+        >
           Save
-        </Button>
+        </LoadingButton>
       </FormControl>
     </Box>
   );

--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -8,7 +8,9 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { SxProps } from '@mui/system';
 import React from 'react';
 import { useGlobalState } from '../../GlobalStateProvider';
 import PendulumApi from '../../lib/api';
@@ -154,7 +156,11 @@ function NodeSelection(props: NodeSelectionProps) {
   );
 }
 
-function NodeSelectionDrawer() {
+interface Props {
+  buttonStyle?: SxProps;
+}
+
+function NodeSelectionDrawer(props: Props) {
   const { state } = useGlobalState();
 
   const [open, setOpen] = React.useState(false);
@@ -173,16 +179,18 @@ function NodeSelectionDrawer() {
   const closeDrawer = () => setOpen(false);
 
   return (
-    <div>
-      <Button onClick={toggleDrawer(true)} endIcon={<KeyboardArrowDownIcon />} color='primary'>
-        {state.currentNode ? state.currentNode.display_name : 'Not connected'}
-      </Button>
+    <>
+      <Tooltip title={state.currentNode?.wss_endpoint || ''}>
+        <Button onClick={toggleDrawer(true)} endIcon={<KeyboardArrowDownIcon />} color='primary' sx={props.buttonStyle}>
+          {state.currentNode ? state.currentNode.display_name : 'Not connected'}
+        </Button>
+      </Tooltip>
       <Drawer anchor='left' open={open} onClose={toggleDrawer(false)}>
         <Box sx={{ width: 300, padding: 2 }} role='presentation'>
           <NodeSelection onSave={closeDrawer} />
         </Box>
       </Drawer>
-    </div>
+    </>
   );
 }
 

--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -157,8 +157,6 @@ function NodeSelection(props: NodeSelectionProps) {
 function NodeSelectionDrawer() {
   const { state } = useGlobalState();
 
-  console.log('state', state);
-
   const [open, setOpen] = React.useState(false);
 
   const toggleDrawer = (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {

--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -1,6 +1,5 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
@@ -22,7 +21,7 @@ function NodeSelection(props: NodeSelectionProps) {
   const { state, setState } = useGlobalState();
   const [selectedNode, setSelectedNode] = React.useState<Node>(state.currentNode || getDefaultNode());
 
-  const [customNodeURL, setCustomNodeURL] = React.useState<string>(selectedNode.url);
+  const [customNodeURL, setCustomNodeURL] = React.useState<string>('ws://localhost:8844');
   const [customAMMAddress, setCustomAMMAddress] = React.useState<string>(selectedNode.amm_address);
   const [showCustomNodeField, setShowCustomNodeField] = React.useState(selectedNode?.display_name === 'Custom');
 
@@ -38,14 +37,16 @@ function NodeSelection(props: NodeSelectionProps) {
     }
   };
 
-  const onSave = () => {
+  const onSave = async () => {
     if (selectedNode?.display_name === 'Custom') {
       const customNode = { ...selectedNode, url: customNodeURL, amm_address: customAMMAddress };
-      PendulumApi.get().init(customNode.url);
+      // await initialization before changing global state because
+      // other components listen to state and would use potentially outdated api
+      await PendulumApi.get().init(customNode.url);
       setState({ ...state, currentNode: customNode });
       setDefaultNode(customNode);
     } else if (selectedNode) {
-      PendulumApi.get().init(selectedNode.url);
+      await PendulumApi.get().init(selectedNode.url);
       setDefaultNode(selectedNode);
       setState({ ...state, currentNode: selectedNode });
     }

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -37,37 +37,37 @@ export default function Topbar() {
       style={{ borderBottom: '1px solid #eee' }}
       className={classes.appBar}
     >
-      <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'center' }}>
-        <Box sx={{ flexGrow: 1 }}>
-          <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
-            <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.5em ' }} />
+      <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'flex-start', flexDirection: 'column', padding: 1 }}>
+        <Box sx={{ alignItems: 'center', display: 'flex', width: '100%' }}>
+          <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.5em ' }} />
+          <Box sx={{ flexGrow: 1 }}>
             <Typography variant='h6' color='inherit'>
               Pendulum
             </Typography>
           </Box>
-          <NodeSelectionDrawer />
+          <nav style={{ display: 'flex', marginRight: 6 }}>
+            <Link to='/balances' style={{ textDecoration: 'none', display: 'inline-block' }}>
+              <Button style={{ display: 'block' }}>Balances</Button>
+            </Link>
+            <Link to='/bridge' style={{ textDecoration: 'none', display: 'inline-block' }}>
+              <Button style={{ display: 'block' }}>Bridge</Button>
+            </Link>
+            <Link to='/amm' style={{ textDecoration: 'none', display: 'inline-block' }}>
+              <Button style={{ display: 'block', minWidth: 'initial' }}>AMM</Button>
+            </Link>
+          </nav>
+          {state.accountSecret ? (
+            <Button onClick={(e) => setElement(e.currentTarget)} variant='outlined'>
+              {state.accountName}
+            </Button>
+          ) : (
+            <Button onClick={(e) => setElement(e.currentTarget)} variant='outlined'>
+              Connect account
+            </Button>
+          )}
+          <AccountDialog caller={element} open={!!element} onClose={onDialogClose} />
         </Box>
-        <nav style={{ display: 'flex', marginRight: 6 }}>
-          <Link to='/balances' style={{ textDecoration: 'none', display: 'inline-block' }}>
-            <Button style={{ display: 'block' }}>Balances</Button>
-          </Link>
-          <Link to='/bridge' style={{ textDecoration: 'none', display: 'inline-block' }}>
-            <Button style={{ display: 'block' }}>Bridge</Button>
-          </Link>
-          <Link to='/amm' style={{ textDecoration: 'none', display: 'inline-block' }}>
-            <Button style={{ display: 'block', minWidth: 'initial' }}>AMM</Button>
-          </Link>
-        </nav>
-        {state.accountSecret ? (
-          <Button onClick={(e) => setElement(e.currentTarget)} variant='outlined'>
-            {state.accountName}
-          </Button>
-        ) : (
-          <Button onClick={(e) => setElement(e.currentTarget)} variant='outlined'>
-            Connect account
-          </Button>
-        )}
-        <AccountDialog caller={element} open={!!element} onClose={onDialogClose} />
+        <NodeSelectionDrawer />
       </Toolbar>
     </AppBar>
   );

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -37,7 +37,7 @@ export default function Topbar() {
       style={{ borderBottom: '1px solid #eee' }}
       className={classes.appBar}
     >
-      <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'flex-start', flexDirection: 'column', padding: 1 }}>
+      <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'flex-start', flexDirection: 'column', padding: 2 }}>
         <Box sx={{ alignItems: 'center', display: 'flex', width: '100%' }}>
           <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.3em ' }} />
           <Box sx={{ flexGrow: 1 }}>

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -39,7 +39,7 @@ export default function Topbar() {
     >
       <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'flex-start', flexDirection: 'column', padding: 1 }}>
         <Box sx={{ alignItems: 'center', display: 'flex', width: '100%' }}>
-          <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.5em ' }} />
+          <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.3em ' }} />
           <Box sx={{ flexGrow: 1 }}>
             <Typography variant='h6' color='inherit'>
               Pendulum
@@ -67,7 +67,7 @@ export default function Topbar() {
           )}
           <AccountDialog caller={element} open={!!element} onClose={onDialogClose} />
         </Box>
-        <NodeSelectionDrawer />
+        <NodeSelectionDrawer buttonStyle={{ marginLeft: '34px', marginTop: '-12px' }} />
       </Toolbar>
     </AppBar>
   );

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -9,12 +9,13 @@ import { useGlobalState } from '../GlobalStateProvider';
 import { useState } from 'react';
 import logo from '../assets/logo.svg';
 import AccountDialog from './AccountDialog';
+import NodeSelectionDrawer from './NodeSelection';
 
 const useStyles = makeStyles((theme) => ({
   appBar: {
     boxShadow: 'none',
     backgroundColor: '#ffffff',
-    height: '80px',
+    height: 'auto',
     justifyContent: 'center'
   }
 }));
@@ -37,11 +38,14 @@ export default function Topbar() {
       className={classes.appBar}
     >
       <Toolbar sx={{ flexWrap: 'nowrap', alignItems: 'center' }}>
-        <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.5em ' }} />
         <Box sx={{ flexGrow: 1 }}>
-          <Typography variant='h6' color='inherit'>
-            Pendulum
-          </Typography>
+          <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+            <img src={logo} className='App-logo' alt='logo' style={{ margin: '0.5em ' }} />
+            <Typography variant='h6' color='inherit'>
+              Pendulum
+            </Typography>
+          </Box>
+          <NodeSelectionDrawer />
         </Box>
         <nav style={{ display: 'flex', marginRight: 6 }}>
           <Link to='/balances' style={{ textDecoration: 'none', display: 'inline-block' }}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,18 @@ import PendulumApi from './lib/api';
 import config from './lib/config';
 
 cryptoWaitReady().then(async () => {
-  PendulumApi.create(config);
+  const api = PendulumApi.create(config);
+
+  const saved = localStorage.getItem('state');
+  const initialValue = JSON.parse(saved || '{}');
+
+  if (initialValue.currentNode) {
+    await api.init(initialValue.currentNode.url);
+  }
 
   ReactDOM.render(
     <React.StrictMode>
-      <App />
+      <App initialState={initialValue} />
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ cryptoWaitReady().then(async () => {
 
   if (initialValue.currentNode) {
     try {
-      await api.init(initialValue.currentNode.url);
+      await api.init(initialValue.currentNode.wss_endpoint);
     } catch (error) {
       initialValue.toast = { message: `Failed to connect to ${initialValue.currentNode.url}`, type: 'error' };
       console.error('Could not initialize api', error);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,7 @@ import PendulumApi from './lib/api';
 import config from './lib/config';
 
 cryptoWaitReady().then(async () => {
-  const api = PendulumApi.create(config);
-  await api.init();
+  PendulumApi.create(config);
 
   ReactDOM.render(
     <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,12 @@ cryptoWaitReady().then(async () => {
   const initialValue = JSON.parse(saved || '{}');
 
   if (initialValue.currentNode) {
-    await api.init(initialValue.currentNode.url);
+    try {
+      await api.init(initialValue.currentNode.url);
+    } catch (error) {
+      initialValue.toast = { message: `Failed to connect to ${initialValue.currentNode.url}`, type: 'error' };
+      console.error('Could not initialize api', error);
+    }
   }
 
   ReactDOM.render(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -168,21 +168,15 @@ export default class PendulumApi {
   }
 
   async bindToPenTokenBalance(address: string, callback: (newVal: PendulumAssetBalance) => void) {
-    let { data: prevBalance } = await this._api.query.system.account(address);
-
     this._api.query.system.account(address, ({ data: curBalance }: { data: AccountData }) => {
       if (curBalance) {
-        const change = curBalance.free.sub(prevBalance.free);
-        if (!change.isZero()) {
-          prevBalance = curBalance;
-          const res = {
-            asset: 'PEN',
-            free: formatWithFactor(curBalance.free, 'PEN'),
-            reserved: formatWithFactor(curBalance.reserved, 'PEN'),
-            frozen: formatWithFactor(curBalance.miscFrozen, 'PEN')
-          };
-          callback(res);
-        }
+        const res = {
+          asset: 'PEN',
+          free: formatWithFactor(curBalance.free, 'PEN'),
+          reserved: formatWithFactor(curBalance.reserved, 'PEN'),
+          frozen: formatWithFactor(curBalance.miscFrozen, 'PEN')
+        };
+        callback(res);
       }
     });
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -221,8 +221,6 @@ export default class PendulumApi {
     let usdcBalance = await this._api.query.tokens.accounts(address, convertAssetToPendulumAsset('USDC'));
     let euroBalance = await this._api.query.tokens.accounts(address, convertAssetToPendulumAsset('EUR'));
 
-    console.log('usdcBalance', usdcBalance);
-
     const formatWithFactor = (balance: Balance, asset: string) => {
       const f = new BN(BALANCE_FACTOR);
       const bn = new BN(balance);
@@ -257,7 +255,6 @@ export default class PendulumApi {
     const contract = new ContractPromise(this._api, AmmABI, contractAddress);
 
     const userAddress = userKeypair.address;
-    console.log('contract', contract);
 
     const value = 0;
     const gasLimit = -1; // always use maximum available amount
@@ -345,14 +342,11 @@ export default class PendulumApi {
       return new Promise<void>((resolve, reject) =>
         query({ value, gasLimit, storageDepositLimit }, amountInPico).signAndSend(userKeypair, (result) => {
           if (result.status.isFinalized) {
-            console.log('result', result);
             console.log((result as any)?.contractEvents?.length > 0);
             // only resolve if contract events were emitted
             if ((result as any).contractEvents && (result as any).contractEvents?.length > 0) {
-              console.log('resolving');
               resolve();
             } else {
-              console.log('rejecting');
               reject(Error('Transaction was not executed successfully.'));
             }
           } else if (result.status.isDropped) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -120,7 +120,8 @@ export default class PendulumApi {
     this._api = await ApiPromise.create({
       provider: ws,
       typesAlias,
-      types: customTypes
+      types: customTypes,
+      throwOnConnect: true
     });
 
     // Retrieve the chain & node information information via rpc calls

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -113,8 +113,8 @@ export default class PendulumApi {
     return this._api;
   }
 
-  async init() {
-    const ws = new WsProvider(this.config.ws);
+  async init(endpoint: string) {
+    const ws = new WsProvider(endpoint);
 
     // Add our custom types to the API creation
     this._api = await ApiPromise.create({
@@ -258,9 +258,8 @@ export default class PendulumApi {
     ];
   }
 
-  getAMMContract(userKeypair: KeyringPair) {
-    const address = this.config.amm_address;
-    const contract = new ContractPromise(this._api, AmmABI, address);
+  getAMMContract(userKeypair: KeyringPair, contractAddress: string) {
+    const contract = new ContractPromise(this._api, AmmABI, contractAddress);
 
     const userAddress = userKeypair.address;
     console.log('contract', contract);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -136,7 +136,7 @@ export default class PendulumApi {
     if (StellarKey.isValidEd25519SecretSeed(seed)) {
       return this.addAccountFromStellarSeed(seed, name);
     } else {
-      const newPair = this._keyring.addFromUri(seed, { name: name || '' });
+      const newPair = this._keyring.addFromUri(seed, { name: name || '' }, 'ed25519');
       const stellaKeyPair = StellarKeyPair.fromRawEd25519Seed(hexToU8a(seed) as Buffer);
 
       let substrateKeys: AccountKeyPairs = {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,5 @@
 const config = {
   address_type: 42,
-  amm_address: process.env.REACT_APP_AMM_ADDRESS || '',
   faucet_amount: 10000,
   decimals: 12,
   friend_bot_url: 'https://friendbot.stellar.org?addr=',
@@ -14,7 +13,6 @@ const config = {
   symbol: 'PEN',
   token: '',
   trust_line_timeout: 100,
-  ws: 'wss://testnet-1.pendulum.satoshipay.tech:443',
   escrow_public_key: 'GALXBW3TNM7QGHTSQENJA2YJGGHLO3TP7Y7RLKWPZIY4CUHNJ3TDMFON',
   testnet_server: 'https://horizon-testnet.stellar.org'
 };

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -1,18 +1,13 @@
-export type Node = { display_name: string; url: string; amm_address: string };
+export type Node = { display_name: string; wss_endpoint: string; amm_address: string };
 
+const rococo_wss_endpoint = process.env.REACT_APP_ROCOCO_WSS_ENDPOINT || 'wss://testnet-1.pendulum.satoshipay.tech:443';
 const rococo_amm_address = process.env.REACT_APP_ROCOCO_AMM_ADDRESS || '';
-const self_hosted_amm_address = process.env.REACT_APP_SELF_HOSTED_AMM_ADDRESS || '';
 
 export const knownNodes: Node[] = [
   {
     display_name: 'Rococo Testnet',
-    url: 'wss://testnet-1.pendulum.satoshipay.tech:443',
+    wss_endpoint: rococo_wss_endpoint,
     amm_address: rococo_amm_address
-  },
-  {
-    display_name: 'Self-hosted Testnet',
-    url: 'wss://testnet-1.pendulum.satoshipay.tech:443',
-    amm_address: self_hosted_amm_address
   }
 ];
 

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -5,7 +5,7 @@ const rococo_amm_address = process.env.REACT_APP_ROCOCO_AMM_ADDRESS || '';
 
 export const knownNodes: Node[] = [
   {
-    display_name: 'Rococo Testnet',
+    display_name: 'Rococo',
     wss_endpoint: rococo_wss_endpoint,
     amm_address: rococo_amm_address
   }

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -1,0 +1,32 @@
+export type Node = { display_name: string; url: string; amm_address: string };
+
+const rococo_amm_address = process.env.REACT_APP_ROCOCO_AMM_ADDRESS || '';
+const self_hosted_amm_address = process.env.REACT_APP_SELF_HOSTED_AMM_ADDRESS || '';
+
+export const knownNodes: Node[] = [
+  {
+    display_name: 'Rococo Testnet',
+    url: 'wss://testnet-1.pendulum.satoshipay.tech:443',
+    amm_address: rococo_amm_address
+  },
+  {
+    display_name: 'Self-hosted Testnet',
+    url: 'wss://testnet-1.pendulum.satoshipay.tech:443',
+    amm_address: self_hosted_amm_address
+  }
+];
+
+const selectedNodeKey = 'selectedNode';
+
+export function getDefaultNode(): Node {
+  const storageSelectedNode = localStorage.getItem(selectedNodeKey);
+  if (storageSelectedNode) {
+    return JSON.parse(storageSelectedNode);
+  } else {
+    return knownNodes[0];
+  }
+}
+
+export function setDefaultNode(node: Node) {
+  localStorage.setItem(selectedNodeKey, JSON.stringify(node));
+}


### PR DESCRIPTION
- [x] Add a button below the Pendulum logo in the top bar that opens a side drawer for node selection
- [x] Add `currentNode` to global state that stores a name, wss endpoint and amm address
- [x] Add `toast` to global state and change existing toast usages. The toast message is stored in global state so that only one Snackbar component can be used throughout the app
- [x] Change `PendulumAPI` to make it possible to initialize with different endpoints

The rococo endpoint and AMM address can be supplied as environment variable.

Closes #51. 