### PR TITLE
Fix custom node won't stay connected to specified port

### DIFF
--- a/src/components/NodeSelection/index.tsx
+++ b/src/components/NodeSelection/index.tsx
@@ -25,7 +25,9 @@ function NodeSelection(props: NodeSelectionProps) {
   const [selectedNode, setSelectedNode] = React.useState<Node>(state.currentNode || getDefaultNode());
 
   const [customNodeInputError, setCustomNodeInputError] = React.useState<string | null>(null);
-  const [customNodeEndpoint, setCustomNodeEndpoint] = React.useState<string>('ws://localhost:8844');
+  const [customNodeEndpoint, setCustomNodeEndpoint] = React.useState<string>(
+    state.currentNode?.display_name.toLowerCase() === 'custom' ? state.currentNode.wss_endpoint : 'ws://localhost:8844'
+  );
   const [customAMMAddress, setCustomAMMAddress] = React.useState<string>(selectedNode.amm_address);
   const [showCustomNodeField, setShowCustomNodeField] = React.useState(selectedNode?.display_name === 'Custom');
 
@@ -57,16 +59,16 @@ function NodeSelection(props: NodeSelectionProps) {
   const onSave = async () => {
     setLoading(true);
     if (selectedNode?.display_name === 'Custom') {
-      const customNode = { ...selectedNode, url: customNodeEndpoint, amm_address: customAMMAddress };
+      const customNode = { ...selectedNode, wss_endpoint: customNodeEndpoint, amm_address: customAMMAddress };
       // await initialization before changing global state because
       // other components listen to state and would use potentially outdated api
       try {
-        await PendulumApi.get().init(customNode.url);
+        await PendulumApi.get().init(customNode.wss_endpoint);
 
         setState({
           ...state,
           currentNode: customNode,
-          toast: { message: `Connected to ${customNode.url}`, type: 'success' }
+          toast: { message: `Connected to ${customNode.wss_endpoint}`, type: 'success' }
         });
         setDefaultNode(customNode);
         props.onSave();
@@ -75,7 +77,7 @@ function NodeSelection(props: NodeSelectionProps) {
         setState({
           ...state,
           currentNode: customNode,
-          toast: { message: `Failed to connect to ${customNode.url}`, type: 'error' }
+          toast: { message: `Failed to connect to ${customNode.wss_endpoint}`, type: 'error' }
         });
       }
     } else if (selectedNode) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,19 @@
+import { cryptoWaitReady } from '@polkadot/util-crypto';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
 import App from './App';
-import reportWebVitals from './reportWebVitals';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { GlobalStateInterface } from './GlobalStateProvider';
+import './index.css';
 import PendulumApi from './lib/api';
 import config from './lib/config';
 import { getDefaultNode } from './lib/nodes';
+import reportWebVitals from './reportWebVitals';
 
 cryptoWaitReady().then(async () => {
   const api = PendulumApi.create(config);
 
   const saved = localStorage.getItem('state');
-  const initialValue = JSON.parse(saved || '{}');
+  const initialValue: Partial<GlobalStateInterface> = JSON.parse(saved || '{}');
 
   if (!initialValue.currentNode) {
     initialValue.currentNode = getDefaultNode();
@@ -20,7 +21,7 @@ cryptoWaitReady().then(async () => {
   try {
     await api.init(initialValue.currentNode.wss_endpoint);
   } catch (error) {
-    initialValue.toast = { message: `Failed to connect to ${initialValue.currentNode.url}`, type: 'error' };
+    initialValue.toast = { message: `Failed to connect to ${initialValue.currentNode.wss_endpoint}`, type: 'error' };
     console.error('Could not initialize api', error);
   }
 


### PR DESCRIPTION
Fixes a bug where the wrong port was shown in the node selection sidebar. The problem was that on saving the custom node, the endpoint was saved as `url` instead of `wss_endpoint`.

Closes #58.